### PR TITLE
Safe crawled comments data in multiple files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@
 
 <!-- | `data` | downloaded data of the web crawler | -->
 
+## Submodules
+
+This project uses submodules. Use `git clone --recursive https://github.com/CodeLionX/CommentSearchEngine.git` when cloning the project or `git submodule update --init` if you've already cloned the repo.
 
 ## Get it running
 

--- a/cse/ArticleIdWriter.py
+++ b/cse/ArticleIdWriter.py
@@ -1,0 +1,67 @@
+import csv
+import os
+
+class ArticleIdWriter(object):
+
+    __delimiter = ''
+    __filepath = ""
+    __file = None
+    __writer = None
+
+    def __init__(self, filepath, delimiter=','):
+        self.__delimiter = delimiter
+        self.__filepath = filepath
+
+
+    def open(self):
+        if not os.path.exists(os.path.dirname(self.__filepath)):
+            try:
+                os.makedirs(os.path.dirname(self.__filepath))
+            except OSError as exc: # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise
+
+        # w  = writing, will empty file and write from beginning (file is created)
+        # a+ = read and append (file is created if it does not exist)
+        self.__file = open(self.__filepath, 'w', newline='')   
+        self.__writer = csv.writer(self.__file)
+        return self
+
+
+    def close(self):
+        self.__file.close()
+
+
+    def printHeader(self, template=None):
+        if template is None:
+            self.__writer.writerow(["article_id", "arcticle_url"])
+        else:
+            self.__writer.writerow(template)
+        self.__file.flush()
+
+
+    def printData(self, data):
+        i = 0
+        for articleUrl in data:
+            self.__writer.writerow([
+                str(i),
+                articleUrl,
+            ])
+            i = i+1
+        self.__file.flush()
+
+
+    def __enter__(self):
+        return self.open()
+
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+
+if __name__ == '__main__':
+    writer = ArticleIdWriter(os.path.join("data", 'arcticleIdsTest.csv'))
+    writer.open()
+    writer.printHeader()
+    writer.printData(['hallo'])
+    writer.close()

--- a/cse/ArticleIdWriter.py
+++ b/cse/ArticleIdWriter.py
@@ -41,13 +41,11 @@ class ArticleIdWriter(object):
 
 
     def printData(self, data):
-        i = 0
-        for articleUrl in data:
+        for i, articleUrl in enumerate(data):
             self.__writer.writerow([
                 str(i),
                 articleUrl,
             ])
-            i = i+1
         self.__file.flush()
 
 

--- a/cse/AuthorMappingWriter.py
+++ b/cse/AuthorMappingWriter.py
@@ -1,0 +1,65 @@
+import csv
+import os
+
+class AuthorMappingWriter(object):
+
+    __delimiter = ''
+    __filepath = ""
+    __file = None
+    __writer = None
+
+    def __init__(self, filepath, delimiter=','):
+        self.__delimiter = delimiter
+        self.__filepath = filepath
+
+
+    def open(self):
+        if not os.path.exists(os.path.dirname(self.__filepath)):
+            try:
+                os.makedirs(os.path.dirname(self.__filepath))
+            except OSError as exc: # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise
+
+        # w  = writing, will empty file and write from beginning (file is created)
+        # a+ = read and append (file is created if it does not exist)
+        self.__file = open(self.__filepath, 'w', newline='')   
+        self.__writer = csv.writer(self.__file)
+        return self
+
+
+    def close(self):
+        self.__file.close()
+
+
+    def printHeader(self, template=None):
+        if template is None:
+            self.__writer.writerow(["author_id", "author"])
+        else:
+            self.__writer.writerow(template)
+        self.__file.flush()
+
+
+    def printData(self, data):
+        for author in data:
+            self.__writer.writerow([
+                str(data[author]),
+                author,
+            ])
+        self.__file.flush()
+
+
+    def __enter__(self):
+        return self.open()
+
+
+    def __exit__(self, type, value, traceback):
+        self.close()
+
+
+if __name__ == '__main__':
+    writer = AuthorMappingWriter(os.path.join("data", 'AuthorMappingTest.csv'))
+    writer.open()
+    writer.printHeader()
+    writer.printData({'authorName': 0})
+    writer.close()

--- a/cse/CommentIdWriter.py
+++ b/cse/CommentIdWriter.py
@@ -10,6 +10,7 @@ class CommentIdWriter(object):
 
     __commentIdMap = {}
     __nextCommentId = 0
+    __currentArticle = None
 
 
     def __init__(self, filepath, delimiter=','):
@@ -39,6 +40,10 @@ class CommentIdWriter(object):
 
         
     def processCommentIds(self, data):
+        if self.__currentArticle is not data["article_id"]:
+            self.printData()
+            self.__currentArticle = data["article_id"]
+
         tempCommentData = {}
         for commentId in data["comments"]:
             if commentId not in self.__commentIdMap:
@@ -59,7 +64,6 @@ class CommentIdWriter(object):
 
         data["comments"] = tempCommentData
         data
-        # todo: Flush CommenIdMap after every article
 
 
     def printHeader(self, template=None):

--- a/cse/CommentIdWriter.py
+++ b/cse/CommentIdWriter.py
@@ -1,7 +1,8 @@
 import csv
 import os
+from cse.pipeline.Handler import Handler
 
-class CommentIdWriter(object):
+class CommentIdWriter(Handler):
 
     __delimiter = ''
     __filepath = ""
@@ -39,7 +40,7 @@ class CommentIdWriter(object):
         self.__file.close()
 
         
-    def processCommentIds(self, data):
+    def process(self, ctx, data):
         if self.__currentArticle is not data["article_id"]:
             self.printData()
             self.__currentArticle = data["article_id"]
@@ -63,6 +64,8 @@ class CommentIdWriter(object):
                 pass
 
         data["comments"] = tempCommentData
+
+        ctx.write(data)
 
 
     def printHeader(self, template=None):

--- a/cse/CommentIdWriter.py
+++ b/cse/CommentIdWriter.py
@@ -63,7 +63,6 @@ class CommentIdWriter(object):
                 pass
 
         data["comments"] = tempCommentData
-        data
 
 
     def printHeader(self, template=None):

--- a/cse/CommentIdWriter.py
+++ b/cse/CommentIdWriter.py
@@ -1,0 +1,93 @@
+import csv
+import os
+
+class CommentIdWriter(object):
+
+    __delimiter = ''
+    __filepath = ""
+    __file = None
+    __writer = None
+
+    __commentIdMap = {}
+    __nextCommentId = 0
+
+
+    def __init__(self, filepath, delimiter=','):
+        self.__delimiter = delimiter
+        self.__filepath = filepath
+
+
+    def open(self):
+        if not os.path.exists(os.path.dirname(self.__filepath)):
+            try:
+                os.makedirs(os.path.dirname(self.__filepath))
+            except OSError as exc: # Guard against race condition
+                if exc.errno != errno.EEXIST:
+                    raise
+
+        # w  = writing, will empty file and write from beginning (file is created)
+        # a+ = read and append (file is created if it does not exist)
+        self.__file = open(self.__filepath, 'w', newline='')   
+        self.__writer = csv.writer(self.__file)
+        self.printHeader()
+        return self
+
+
+    def close(self):
+        self.printData()
+        self.__file.close()
+
+        
+    def processCommentIds(self, data):
+        tempCommentData = {}
+        for commentId in data["comments"]:
+            if commentId not in self.__commentIdMap:
+                self.__commentIdMap[commentId] = self.__nextCommentId
+                self.__nextCommentId = self. __nextCommentId + 1
+            if data["comments"][commentId]["parent_comment_id"] and data["comments"][commentId]["parent_comment_id"] not in self.__commentIdMap:
+                self.__commentIdMap[ data["comments"][commentId]["parent_comment_id"] ] = self.__nextCommentId
+                self.__nextCommentId = self. __nextCommentId + 1
+            
+            newCommentId = self.__commentIdMap[commentId]
+            tempCommentData[newCommentId] = data["comments"][commentId]
+
+            try:
+                newParentId = self.__commentIdMap[ data["comments"][commentId]["parent_comment_id"] ]
+                tempCommentData[newCommentId]["parent_comment_id"] = newParentId
+            except KeyError:
+                pass
+
+        data["comments"] = tempCommentData
+        data
+        # todo: Flush CommenIdMap after every article
+
+
+    def printHeader(self, template=None):
+        if template is None:
+            self.__writer.writerow(["ccid", "cid"])
+        else:
+            self.__writer.writerow(template)
+        self.__file.flush()
+
+
+    def printData(self):
+        if not self.__writer:
+            self.open()
+
+        for commentId in self.__commentIdMap:
+                       
+            self.__writer.writerow([
+                str(self.__commentIdMap[commentId]),
+                commentId
+            ])
+        self.__file.flush()
+        self.__commentIdMap = {}
+
+
+
+    def __enter__(self):
+        return self.open()
+
+
+    def __exit__(self, type, value, traceback):
+        self.close()

--- a/cse/CommentReader.py
+++ b/cse/CommentReader.py
@@ -50,35 +50,6 @@ class CommentReader(object):
 
     def readAllData(self):
         raise DeprecationWarning("deprecated and not longer supported")
-        if not self.__authors:
-            self.__loadAuthors()
-        return
-        first = True
-
-        articleUrl = ""
-        articleId = ""
-        comments = {}
-
-        self.__commentsFile.seek(0)
-        self.__articlesFile.seek(0)
-        articlesFormat = next(self.__articlesReader)
-        currentArticle = next(self.__articlesReader)
-        for row in self.__commentReader:
-            if first:
-                first = False
-                continue
-
-            articleUrl = row[1]
-            articleId = row[8]
-
-            commentId = row[0]
-            comments[commentId] = self.__parseRow(row)
-
-        return {
-            "article_url": articleUrl,
-            "article_id": articleId,
-            "comments": comments
-        }
 
     
     def __loadAuthors(self):
@@ -94,24 +65,6 @@ class CommentReader(object):
 
     def __parseRow(self, row):
         raise DeprecationWarning("deprecated and not longer supported")
-        if not self.__authors:
-            self.__loadAuthors()
-        author = row[2]
-        text = row[3].replace("\\n", "\n")
-        timestamp = row[4]
-        parentId = row[5]
-        upvotes = int(row[6])
-        downvotes = int(row[7])
-
-        return {
-            "comment_author": author,
-            "comment_text" : text,
-            "timestamp" : timestamp,
-            "parent_comment_id" : parentId,
-            "upvotes" : upvotes,
-            "downvotes": downvotes
-        }
-
 
     def __parseIterRow(self, row):
         if not self.__authors:

--- a/cse/CommentSpider.py
+++ b/cse/CommentSpider.py
@@ -81,7 +81,7 @@ class CommentSpider(SitemapSpider):
         self.__writeArcticleIds()
 
     def __writeArcticleIds(self):
-        writer = ArticleIdWriter(os.path.join("data", 'arcticleIds.csv'))
+        writer = ArticleIdWriter(os.path.join("data", 'articleIds.csv'))
         writer.open()
         writer.printHeader()
         writer.printData(self.__visitedURLs)

--- a/cse/CommentSpider.py
+++ b/cse/CommentSpider.py
@@ -8,17 +8,20 @@ from scrapy.crawler import CrawlerProcess
 from cse.WpApiDataPipelineBootstrap import WpApiDataPipelineBootstrap as PipelineBootstrap
 from cse.WpOldApiDataPipelineBootstrap import WpOldApiDataPipelineBootstrap as PipelineBootstrapOld
 from cse.CommentWriter import CommentWriter
+from cse.ArticleIdWriter import ArticleIdWriter
 
 class CommentSpider(SitemapSpider):
     # this spider scrapes a single article within the domain washingtonpost.com (https://www.washingtonpost.com/)
     name = 'washingtonpost.com'
     #sitemap_urls = ['https://www.washingtonpost.com/robots.txt']
-    sitemap_urls = ['http://www.washingtonpost.com/news-politics-sitemap.xml', 'http://www.washingtonpost.com/news-opinions-sitemap.xml','http://www.washingtonpost.com/news-local-sitemap.xml','http://www.washingtonpost.com/news-national-sitemap.xml']
-    other_urls = []
+    sitemap_urls = []#'http://www.washingtonpost.com/news-politics-sitemap.xml', 'http://www.washingtonpost.com/news-opinions-sitemap.xml','http://www.washingtonpost.com/news-local-sitemap.xml','http://www.washingtonpost.com/news-national-sitemap.xml']
+    other_urls = ['http://www.washingtonpost.com/news/the-fix/wp/2017/11/26/james-b-comey-tweeted-about-freedom-of-the-press-minutes-after-trump-attacked-cnn/', 'https://www.washingtonpost.com/politics/some-house-republicans-wary-of-bannons-plans-for-2018/2017/11/27/74961048-d34e-11e7-9ad9-ca0619edfa05_story.html','https://www.washingtonpost.com/politics/courts_law/supreme-court-to-consider-major-digital-privacy-case-on-microsoft-email-storage/2017/10/16/b1e74936-b278-11e7-be94-fabb0f1e9ffb_story.html']
 
     __pbs = None
     __pbsOld = None
     __writer = None
+    __visitedURLs = []
+    __nextArcticleId = 0
 
 
     def __init__(self):
@@ -59,15 +62,26 @@ class CommentSpider(SitemapSpider):
 
     def spider_closed(self, spider):
         self.__teardownFileWriter()
+        self.__writeArcticleIds()
+
+    def __writeArcticleIds(self):
+        writer = ArticleIdWriter(os.path.join("data", 'arcticleIds.csv'))
+        writer.open()
+        writer.printHeader()
+        writer.printData(self.__visitedURLs)
+        writer.close()
 
 
     def parse(self, response):
         try:
-            self.__pbs.crawlComments(response.url)
+            self.__pbs.crawlComments(response.url, self.__nextArcticleId)
         except:
             print('fail new API\n')
 
         try:
-            self.__pbsOld.crawlComments(response.url)
+            self.__pbsOld.crawlComments(response.url, self.__nextArcticleId)
         except:
             print('fail old API\n')
+        
+        self.__visitedURLs.append(response.url)
+        self.__nextArcticleId = self.__nextArcticleId + 1

--- a/cse/CommentSpider.py
+++ b/cse/CommentSpider.py
@@ -8,7 +8,7 @@ from scrapy.crawler import CrawlerProcess
 from cse.WpApiDataPipelineBootstrap import WpApiDataPipelineBootstrap as PipelineBootstrap
 from cse.WpOldApiDataPipelineBootstrap import WpOldApiDataPipelineBootstrap as PipelineBootstrapOld
 from cse.CommentWriter import CommentWriter
-from cse.CommentIdWriter import CommentIdWriter
+from cse.pipeline.CommentIdHandler import CommentIdHandler
 from cse.ArticleIdWriter import ArticleIdWriter
 
 class CommentSpider(SitemapSpider):
@@ -20,7 +20,7 @@ class CommentSpider(SitemapSpider):
     __pbs = None
     __pbsOld = None
     __writer = None
-    __commentIdWriter = None
+    __commentIdHandler = None
     __visitedURLs = []
     __nextArcticleId = 0
 
@@ -32,9 +32,9 @@ class CommentSpider(SitemapSpider):
         self.other_urls = urls
 
         self.__setupCommentIdWriter("commentIdMap.csv")
-        self.__pbs = PipelineBootstrap(self.__commentIdWriter)
+        self.__pbs = PipelineBootstrap(self.__commentIdHandler)
         self.__pbs.setupPipeline()
-        self.__pbsOld = PipelineBootstrapOld(self.__commentIdWriter)
+        self.__pbsOld = PipelineBootstrapOld(self.__commentIdHandler)
         self.__pbsOld.setupPipeline()
         self.__setupFileWriter("comments.csv")
 
@@ -52,12 +52,12 @@ class CommentSpider(SitemapSpider):
 
 
     def __setupCommentIdWriter(self, filename):
-        writer = CommentIdWriter(os.path.join("data", filename))
-        self.__commentIdWriter = writer
+        writer = CommentIdHandler(os.path.join("data", filename))
+        self.__commentIdHandler = writer
 
 
     def __teardownCommentIdWriter(self):
-        self.__commentIdWriter.close()
+        self.__commentIdHandler.close()
 
 
     def __setupFileWriter(self, filename):

--- a/cse/CommentWriter.py
+++ b/cse/CommentWriter.py
@@ -1,6 +1,7 @@
 import csv
 import os
 from cse.AuthorMappingWriter import AuthorMappingWriter
+from collections import OrderedDict
 
 class CommentWriter(object):
 
@@ -9,7 +10,7 @@ class CommentWriter(object):
     __file = None
     __writer = None
     __nextAuthorId = 0
-    __authorIdMapping = {}
+    __authorIdMapping = OrderedDict()
 
 
     def __init__(self, filepath, delimiter=','):

--- a/cse/CommentWriter.py
+++ b/cse/CommentWriter.py
@@ -46,14 +46,13 @@ class CommentWriter(object):
 
     def printHeader(self, template=None):
         if template is None:
-            self.__writer.writerow(["cid", "url", "author_id", "text", "time", "parent", "upvotes", "downvotes", "article_id"])
+            self.__writer.writerow(["cid", "article_id", "author_id", "text", "time", "parent", "upvotes", "downvotes", ])
         else:
             self.__writer.writerow(template)
         self.__file.flush()
 
 
     def printData(self, data):
-        article_url = data["article_url"]
         article_id = data["article_id"]
 
         for commentId in data["comments"]:
@@ -67,14 +66,13 @@ class CommentWriter(object):
             
             self.__writer.writerow([
                 str(commentId),
-                article_url,
+                article_id,
                 authorId,
                 data["comments"][commentId]["comment_text"].replace("\n", "\\n"),
                 data["comments"][commentId]["timestamp"],
                 str(data["comments"][commentId]["parent_comment_id"]),
                 data["comments"][commentId]["upvotes"],
-                data["comments"][commentId]["downvotes"],
-                article_id
+                data["comments"][commentId]["downvotes"]
             ])
         self.__file.flush()
 

--- a/cse/CommentWriter.py
+++ b/cse/CommentWriter.py
@@ -35,11 +35,11 @@ class CommentWriter(object):
 
     def close(self):
         self.__file.close()
-        mappingWrtier = AuthorMappingWriter(os.path.join(os.path.dirname(self.__filepath), 'authorMapping.csv'))
-        mappingWrtier.open()
-        mappingWrtier.printHeader()
-        mappingWrtier.printData(self.__authorIdMapping)
-        mappingWrtier.close()
+        mappingWriter = AuthorMappingWriter(os.path.join(os.path.dirname(self.__filepath), 'authorMapping.csv'))
+        mappingWriter.open()
+        mappingWriter.printHeader()
+        mappingWriter.printData(self.__authorIdMapping)
+        mappingWriter.close()
 
         
         

--- a/cse/CommentWriter.py
+++ b/cse/CommentWriter.py
@@ -8,7 +8,6 @@ class CommentWriter(object):
     __filepath = ""
     __file = None
     __writer = None
-    __nextCommentId = 0
     __nextAuthorId = 0
     __authorIdMapping = {}
 

--- a/cse/SearchEngine.py
+++ b/cse/SearchEngine.py
@@ -158,7 +158,6 @@ class SearchEngine():
 
                 if cidTuples:
                     allCidTuples = allCidTuples + cidTuples
-
         return self.__loadDocumentTextForCids(set([cid for cid, _ in allCidTuples]))
 
 
@@ -185,7 +184,7 @@ class SearchEngine():
         results = []
         commentPointers = set()
 
-        if not cids:
+        if cids is None or cids is []:
             return results
 
         # get document pointers
@@ -197,7 +196,7 @@ class SearchEngine():
                     print(self.__class__.__name__ + ":", "comment", cid, "not found!")
 
         # load document text
-        with CommentReader(os.path.join("data", "comments.data")).open() as cr:
+        with CommentReader(os.path.join("data", "comments.data"),os.path.join("data", "articleIds.data"),os.path.join("data", "authorMapping.data")).open() as cr:
             for pointer, rowData in enumerate(cr):
                 if pointer in commentPointers:
                     results.append(rowData["comment_text"])
@@ -286,7 +285,8 @@ class CustomPpStep(PreprocessorStep):
 
 if __name__ == '__main__':
     se = SearchEngine("data")
-    #se.index("data")
+    # se.index()
     #se.printAssignment2QueryResults()
     #se.printAssignment3QueryResults()
-    se.printTestQueryResults()
+    #se.printTestQueryResults()
+    print(se.search("microsoft")[:5])

--- a/cse/WpApiAdapter.py
+++ b/cse/WpApiAdapter.py
@@ -48,7 +48,7 @@ class WpApiAdapter(Handler):
         return countInList(comments, 0)
 
 
-    def loadComments(self, url):
+    def loadComments(self, url, id):
         if self.__handlerContext is None:
             raise Exception("WpApiAdapter must be used within a WpApiAdapterHandler to use pipelining functionality!")
         
@@ -61,7 +61,7 @@ class WpApiAdapter(Handler):
         )
 
         data = Util.fromJsonString(response.text)
-        assetId = data['data']['asset']['id']
+        assetId = id
         commentsNode = data['data']['asset']['comments']
         
         comments = self.__processComments(commentsNode, url, assetId)

--- a/cse/WpApiAdapter.py
+++ b/cse/WpApiAdapter.py
@@ -48,7 +48,7 @@ class WpApiAdapter(Handler):
         return countInList(comments, 0)
 
 
-    def loadComments(self, url, id):
+    def loadComments(self, url, articleId):
         if self.__handlerContext is None:
             raise Exception("WpApiAdapter must be used within a WpApiAdapterHandler to use pipelining functionality!")
         
@@ -61,10 +61,10 @@ class WpApiAdapter(Handler):
         )
 
         data = Util.fromJsonString(response.text)
-        assetId = id
+        assetId = data['data']['asset']['id']
         commentsNode = data['data']['asset']['comments']
         
-        comments = self.__processComments(commentsNode, url, assetId)
+        comments = self.__processComments(commentsNode, url, assetId, articleId)
 
 
     def __buildInitialRequstPayload(self, url):
@@ -99,12 +99,12 @@ class WpApiAdapter(Handler):
         }
 
 
-    def __processComments(self, commentsNode, url, assetId, parentId=None):
+    def __processComments(self, commentsNode, url, assetId, articleId, parentId=None):
         commentsHasNextPage = commentsNode['hasNextPage']
         commentsCursor = commentsNode['endCursor']
         comments = commentsNode['nodes']
 
-        data={"url": url, "assetId": assetId, "parentId": parentId, "comments": comments}
+        data={"url": url, "assetId": articleId, "parentId": parentId, "comments": comments}
         self.__handlerContext.write(data)
 
         # check for replies
@@ -115,16 +115,16 @@ class WpApiAdapter(Handler):
             replies = com['replies']['nodes']
 
             if(repliesHasNextPage):
-                com['replies']['nodes'] = replies + self.__loadMoreReplies(url, assetId, repliesCursor, repliesParentId)
+                com['replies']['nodes'] = replies + self.__loadMoreReplies(url, assetId, repliesCursor, articleId, repliesParentId)
 
         # check for another page
         if(commentsHasNextPage):
-            comments = comments + self.__loadMoreComments(url, assetId, commentsCursor)
+            comments = comments + self.__loadMoreComments(url, assetId, commentsCursor, articleId)
 
         return comments
 
 
-    def __loadMoreComments(self, url, assetId, cursor):
+    def __loadMoreComments(self, url, assetId, cursor, articleId):
         payload = self.__buildMoreRequestPayload(assetId, cursor=cursor)
 
         response = requests.request("POST", 
@@ -136,10 +136,10 @@ class WpApiAdapter(Handler):
         data = Util.fromJsonString(response.text)
         commentsNode = data['data']['comments']
 
-        return self.__processComments(commentsNode, url, assetId)
+        return self.__processComments(commentsNode, url, assetId, articleId)
 
 
-    def __loadMoreReplies(self, url, assetId, cursor, parentId):
+    def __loadMoreReplies(self, url, assetId, cursor, articleId, parentId):
         payload = self.__buildMoreRequestPayload(assetId, cursor=cursor, parentId=parentId)
 
         response = requests.request("POST", 
@@ -151,7 +151,7 @@ class WpApiAdapter(Handler):
         data = Util.fromJsonString(response.text)
         commentsNode = data['data']['comments']
 
-        return self.__processComments(commentsNode, url, assetId, parentId)
+        return self.__processComments(commentsNode, url, assetId, articleId, parentId)
 
 
     # inherited from cse.pipeline.Handler

--- a/cse/WpApiDataPipelineBootstrap.py
+++ b/cse/WpApiDataPipelineBootstrap.py
@@ -15,15 +15,17 @@ class WpApiDataPipelineBootstrap(Handler):
 
     __countHandler = None
     __duplicateHandler = None
+    __commentIdHandler = None
 
 
-    def __init__(self):
+    def __init__(self, commentIdHandler):
         super(WpApiDataPipelineBootstrap, self).__init__("PipelineBootstrap for data listeners")
         self.__wpApiAdapter = WpApiAdapter()
         self.__countHandler = CountHandler("Counter")
         self.__duplicateHandler = DuplicateHandler()
         self.__listenersLock = Lock()
         self.__wasPipeBuild = False
+        self.__commentIdHandler = commentIdHandler
 
 
     def setupPipeline(self, asynchronous=False):
@@ -41,6 +43,7 @@ class WpApiDataPipelineBootstrap(Handler):
         self.__pipeline.addLast(WpApiParser()) # recursive datastructures -> flat datastructures
         self.__pipeline.addLast(RemoveDuplicatesHandler())
         #self.__pipeline.addLast(self.__duplicateHandler) # debug: count comment ids
+        self.__pipeline.addLast(self.__commentIdHandler)
         self.__pipeline.addLast(self.__countHandler) # debug: counts all comments
         #self.__pipeline.addLast(DebugHandler("DebugHandler")) # debug: shows some processing output
         self.__pipeline.addLast(self) # _ -> listeners

--- a/cse/WpApiDataPipelineBootstrap.py
+++ b/cse/WpApiDataPipelineBootstrap.py
@@ -55,11 +55,11 @@ class WpApiDataPipelineBootstrap(Handler):
                 callback(data)
 
 
-    def crawlComments(self, url):
+    def crawlComments(self, url, id):
         if not self.__wasPipeBuild:
             raise Exception("Pipeline uninitialized! First init pipeline with setupPipeline()")
         self.__countHandler.reset()
-        self.__wpApiAdapter.loadComments(url)
+        self.__wpApiAdapter.loadComments(url, id)
         print("Processed comments: " + str(self.__countHandler.get()))
         self.__duplicateHandler.getDuplicates()
 

--- a/cse/WpOldApiAdapter.py
+++ b/cse/WpOldApiAdapter.py
@@ -20,17 +20,17 @@ class WpOldApiAdapter(Handler):
     def __init__(self):
         super()
 
-    def loadComments(self, url):
+    def loadComments(self, url, id):
         if self.__handlerContext is None:
             raise Exception("WpOldApiAdapter must be used within a processing pipeline")
         
         data = self.__loadInitialRootComments(url)
         
-        self.__processComments(data, url)
+        self.__processComments(data, url, id)
 
         while data['hasMoreChildren'] == "true":
             data = self.__loadMoreRootComments(url, data['nextPageAfter'])
-            self.__processComments(data, url)
+            self.__processComments(data, url, id)
 
 
     def __buildDataSkeleton(self, url, assetId=None):
@@ -40,7 +40,7 @@ class WpOldApiAdapter(Handler):
             "comments" : []
         }
 
-    def __processComments(self, data, url):
+    def __processComments(self, data, url, id):
         commentList = {}
 
         for entry in data["entries"]:
@@ -78,7 +78,7 @@ class WpOldApiAdapter(Handler):
                 pass
 
         # write comments to pipeline
-        commentsObject = self.__buildDataSkeleton(url)
+        commentsObject = self.__buildDataSkeleton(url, id)
         commentsObject["comments"] = commentList
         self.__handlerContext.write(commentsObject)
 

--- a/cse/WpOldApiAdapter.py
+++ b/cse/WpOldApiAdapter.py
@@ -73,7 +73,7 @@ class WpOldApiAdapter(Handler):
             }
             try:
                 directReplies = self.__loadReplies(entry["object"]["id"], entry["object"]["accumulators"]["repliesCount"], entry["pageAfter"])
-                self.__processComments(directReplies, url)
+                self.__processComments(directReplies, url, id)
             except KeyError:
                 pass
 

--- a/cse/WpOldApiDataPipelineBootstrap.py
+++ b/cse/WpOldApiDataPipelineBootstrap.py
@@ -59,7 +59,6 @@ class WpOldApiDataPipelineBootstrap(Handler):
         self.__countHandler.reset()
         self.__wpApiAdapter.loadComments(url, id)
         print("Processed comments with old API: " + str(self.__countHandler.get()))
-        self.__duplicateHandler.getDuplicates()
 
 
 

--- a/cse/WpOldApiDataPipelineBootstrap.py
+++ b/cse/WpOldApiDataPipelineBootstrap.py
@@ -13,15 +13,17 @@ class WpOldApiDataPipelineBootstrap(Handler):
     __listenersLock = None
 
     __countHandler = None
+    __commentIdHandler = None
 
 
-    def __init__(self):
+    def __init__(self, commentIdHandler):
         super(WpOldApiDataPipelineBootstrap, self).__init__("PipelineBootstrapOld for data listeners")
         self.__wpApiAdapter = WpOldApiAdapter()
         self.__countHandler = CountHandler("CounterOld")
         self.__listeners = []
         self.__listenersLock = Lock()
         self.__wasPipeBuild = False
+        self.__commentIdHandler = commentIdHandler
 
 
     def setupPipeline(self, asynchronous=False):
@@ -37,6 +39,7 @@ class WpOldApiDataPipelineBootstrap(Handler):
         self.__pipeline = Pipeline(ctxFactory)
         self.__pipeline.addLast(self.__wpApiAdapter) # url/json -> flat datastructures
         self.__pipeline.addLast(RemoveDuplicatesHandler())
+        self.__pipeline.addLast(self.__commentIdHandler)
         self.__pipeline.addLast(self.__countHandler) # debug: counts all comments
         self.__pipeline.addLast(self) # _ -> listeners
 

--- a/cse/WpOldApiDataPipelineBootstrap.py
+++ b/cse/WpOldApiDataPipelineBootstrap.py
@@ -50,11 +50,11 @@ class WpOldApiDataPipelineBootstrap(Handler):
                 callback(data)
 
 
-    def crawlComments(self, url):
+    def crawlComments(self, url, id):
         if not self.__wasPipeBuild:
             raise Exception("Pipeline uninitialized! First init pipeline with setupPipeline()")
         self.__countHandler.reset()
-        self.__wpApiAdapter.loadComments(url)
+        self.__wpApiAdapter.loadComments(url, id)
         print("Processed comments with old API: " + str(self.__countHandler.get()))
         self.__duplicateHandler.getDuplicates()
 

--- a/cse/indexing/FileIndexer.py
+++ b/cse/indexing/FileIndexer.py
@@ -44,28 +44,6 @@ class FileIndexer(object):
 
     def indexMultiFile(self):
         raise DeprecationWarning("deprecated and not longer supported")
-        # load multi file index
-        if not os.path.exists(self.__multiFileIndexPath):
-            print("multifile index does not exist...creating new one")
-            self.__createMultiFileIndex()
-
-        multiFileMap = MultiFileMap()
-        multiFileMap.loadJson(self.__multiFileIndexPath)
-        self.__index = InvertedIndexWriter(self.__directory)
-
-        print("multifile index and inverted index instance loaded")
-
-        # load all article ids = filenames
-        filenames = []
-        for cid in multiFileMap.listCids():
-            filenames.append(multiFileMap.get(cid)["fileId"])
-
-        # process each file
-        for filename in set(filenames):
-            print("Processing file", filename)
-            self.__createIndexForArticle(filename)
-
-        self.__index.close()
 
 
     def __createMultiFileIndex(self):

--- a/cse/indexing/FileIndexer.py
+++ b/cse/indexing/FileIndexer.py
@@ -18,7 +18,9 @@ class FileIndexer(object):
         self.__dictionaryPath       = os.path.join(directory, "dictionary.index")
         self.__postingListsPath     = os.path.join(directory, "postingLists.index")
         self.__dataFolderPath       = os.path.join(directory, "raw")
-        self.__dataFilePath         = os.path.join(directory, "comments.data")
+        self.__commentsFilePath     = os.path.join(directory, "comments.data")
+        self.__articleFilePath      = os.path.join(directory, "articleIds.data")
+        self.__authorsFilePath      = os.path.join(directory, "authorMapping.data")
 
 
     def index(self):
@@ -26,7 +28,7 @@ class FileIndexer(object):
         documentMap = DocumentMap(self.__documentMapPath).open()
 
         #print("Starting indexing...")
-        with CommentReader(self.__dataFilePath) as dataFile:
+        with CommentReader(self.__commentsFilePath, self.__articleFilePath, self.__authorsFilePath) as dataFile:
             for pointer, data in enumerate(dataFile):
                 try:
                     documentMap.get(data["commentId"])
@@ -41,6 +43,7 @@ class FileIndexer(object):
 
 
     def indexMultiFile(self):
+        raise DeprecationWarning("deprecated and not longer supported")
         # load multi file index
         if not os.path.exists(self.__multiFileIndexPath):
             print("multifile index does not exist...creating new one")
@@ -91,7 +94,7 @@ class FileIndexer(object):
             positionList.sort()
             tokenPositionsDict[token] = positionList
 
-        for token in tokenDict:
+        for token in tokenPositionsDict:
             self.__index.insert(token, cid, tokenPositionsDict[token])
 
 

--- a/cse/pipeline/CommentIdHandler.py
+++ b/cse/pipeline/CommentIdHandler.py
@@ -15,6 +15,7 @@ class CommentIdHandler(Handler):
 
 
     def __init__(self, filepath, delimiter=','):
+        super(CommentIdHandler, self).__init__("Custom Comment Id Handler")
         self.__delimiter = delimiter
         self.__filepath = filepath
 

--- a/cse/pipeline/CommentIdHandler.py
+++ b/cse/pipeline/CommentIdHandler.py
@@ -2,7 +2,7 @@ import csv
 import os
 from cse.pipeline.Handler import Handler
 
-class CommentIdWriter(Handler):
+class CommentIdHandler(Handler):
 
     __delimiter = ''
     __filepath = ""

--- a/cse/pipeline/__init__.py
+++ b/cse/pipeline/__init__.py
@@ -11,6 +11,7 @@ from cse.pipeline.SynchronousHandlerContext import SynchronousHandlerContext
 from cse.pipeline.Pipeline import Pipeline
 from cse.pipeline.stdHandler import (SimpleConsolePrintHandler, SimpleForwardHandler, SinkHandler)
 from cse.pipeline.Handler import Handler
+from cse.pipeline.CommentIdHandler import CommentIdHandler
 
 
 class SyncedHandlerContextFactory:


### PR DESCRIPTION
We decided to decompose the current csv file into multiple files: the first file contains only (custom) article ids and article URLs. The second file contains (custom) comment author ids and comment authors. The third file contains all comment data except that the article URLs and the comment authors are replaced by corresponding ids. Assume a 4 byte number for each id. Sort the comment data by article id. The three csv files should have this format:

 - ~~article id, article url~~
 - ~~comment author id, comment author~~
 - ~~comment id, article id, comment author id, comment text, timestamp, parent comment id, upvotes, downvotes~~

Note: We will also use custom comment_ids and save the mapping in a fourth file:
 - ~~ccid, cid~~

 - ~~Adapt readers to new file formats~~