### PR TITLE
Implement norm caching

### DIFF
--- a/cse/WeightCalculation.py
+++ b/cse/WeightCalculation.py
@@ -53,6 +53,24 @@ def cosineSimilarity(docWeights, queryWeights):
     return float(score)
 
 
+def cosineSimilarityHybrid(docWeights, queryWeights):
+    cache = NormCache()
+    dj = np.array(docWeights)
+    q = np.array(queryWeights)
+
+    # use cache to store norms
+    dj_norm = np.linalg.norm(dj)
+    try:
+        q_norm = cache[tuple(queryWeights)]
+    except KeyError:
+        q_norm = np.linalg.norm(q)
+        cache[tuple(queryWeights)] = q_norm
+    #print(q, dj)
+    score = np.dot(dj, q) / (dj_norm * q_norm)
+    #print(score)
+    return float(score)
+
+
 def oldCosineSimilarity(docWeights, queryWeights):
     dj = np.array(docWeights)
     q = np.array(queryWeights)
@@ -167,3 +185,11 @@ if __name__ == "__main__":
     print("\nWarm cached cosine similarity")
     profileTime(cosineSimilarity, docs, query, warm=True)
     profileMemory(cosineSimilarity, docs, query, warm=True)
+
+    print("\nOnly query norms cached cosine similarity")
+    profileTime(cosineSimilarityHybrid, docs, query, warm=False)
+    profileMemory(cosineSimilarityHybrid, docs, query, warm=False)
+
+    print("\nWarm only query norms cached cosine similarity")
+    profileTime(cosineSimilarityHybrid, docs, query, warm=True)
+    profileMemory(cosineSimilarityHybrid, docs, query, warm=True)

--- a/cse/WeightCalculation.py
+++ b/cse/WeightCalculation.py
@@ -131,7 +131,7 @@ def profileMemory(func, docs, query, warm=False):
     tracemalloc.start()
     results = []
     for doc in docs:
-        r = cosineSimilarity(doc, query)
+        r = func(doc, query)
         results.append(r)
 
     snapshots[func.__name__] = tracemalloc.take_snapshot()

--- a/cse/WeightCalculation.py
+++ b/cse/WeightCalculation.py
@@ -32,13 +32,31 @@ def missingTermWeight():
 
 
 def cosineSimilarity(docWeights, queryWeights):
+    cache = NormCache()
     dj = np.array(docWeights)
     q = np.array(queryWeights)
+
+    # use cache to store norms
+    try:
+        dj_norm = cache[tuple(docWeights)]
+    except KeyError:
+        dj_norm = np.linalg.norm(dj)
+        cache[tuple(docWeights)] = dj_norm
+    try:
+        q_norm = cache[tuple(queryWeights)]
+    except KeyError:
+        q_norm = np.linalg.norm(q)
+        cache[tuple(queryWeights)] = q_norm
     #print(q, dj)
-    score = np.dot(dj, q) / (np.linalg.norm(dj) * np.linalg.norm(q))
+    score = np.dot(dj, q) / (dj_norm * q_norm)
     #print(score)
     return float(score)
 
+def oldCosineSimilarity(docWeights, queryWeights):
+    dj = np.array(docWeights)
+    q = np.array(queryWeights)
+
+    score = np.dot(dj, q) / (np.linalg.norm(dj) * np.linalg.norm(q))
 
 def euclDistance(docWeights, queryWeights):
     dj = np.array(docWeights)
@@ -49,8 +67,93 @@ def euclDistance(docWeights, queryWeights):
     return float(score)
 
 
-if __name__ == "__main__":
-    w1 = [1,4,0,1.4,23.0]
-    w2 = [76,5.7,1,13.5,3.5]
+class NormCache(object):
+    """
+    Singleton Cache from http://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html.
+    Instance Holder
+    """
+    class __NormCache:
+        """
+        Singleton Cache from http://python-3-patterns-idioms-test.readthedocs.io/en/latest/Singleton.html.
+        """
+        def __init__(self):
+            self.cache = {}
+        def __str__(self):
+            return str(self.cache)
+        def __getitem__(self, key):
+            return self.cache[key]
+        def __setitem__(self, key, value):
+            self.cache[key] = value
+    
+    instance = None
+    def __new__(cls): # __new__ is always a classmethod
+        if not NormCache.instance:
+            NormCache.instance = NormCache.__NormCache()
+        return NormCache.instance
+    def __getattr__(self, name):
+        return getattr(self.instance, name)
+    def __setattr__(self, name, value):
+        return setattr(self.instance, name, value)
 
-    print(cosineSimilarity(w1, w2))
+
+if __name__ == "__main__":
+    import cProfile
+    import tracemalloc
+    import pstats
+    import random
+
+    # data
+    DOC_SIZE = 5
+    SAMPLE_SIZE = 200000
+    docs = []
+    for i in range(0, SAMPLE_SIZE):
+        docs.append([random.random() for i in range(DOC_SIZE)])
+    query = [random.random() for i in range(0, DOC_SIZE)]
+
+    print("Testrun for {} documents each containing {} values".format(SAMPLE_SIZE, DOC_SIZE))
+    print("Cached cosine similarity")
+
+    tracemalloc.start()
+    pr = cProfile.Profile()
+    results = []
+    for doc in docs:
+        pr.enable()
+        r = cosineSimilarity(doc, query)
+        pr.disable()
+        results.append(r)
+    
+    snapshot = tracemalloc.take_snapshot()
+    used, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    ps = pstats.Stats(pr)
+    ps.sort_stats('time')
+    ps.print_stats(10)
+
+    print("Memory Snapshot")
+    print("Used memory={}, Peak memory={}".format(used, peak))
+    top_stats = snapshot.statistics('lineno')
+    for stat in top_stats[:10]:
+        print(stat)
+
+    print("Uncached cosine similarity")
+    tracemalloc.start()
+    pr = cProfile.Profile()
+    results = []
+    for doc in docs:
+        pr.enable()
+        r = oldCosineSimilarity(doc, query)
+        pr.disable()
+        results.append(r)
+    
+    snapshot = tracemalloc.take_snapshot()
+    used, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    ps = pstats.Stats(pr)
+    ps.sort_stats('time')
+    ps.print_stats(10)
+
+    print("Memory Snapshot")
+    print("Used memory={}, Peak memory={}".format(used, peak))
+    top_stats = snapshot.statistics('lineno')
+    for stat in top_stats[:10]:
+        print(stat)

--- a/cse/WeightCalculation.py
+++ b/cse/WeightCalculation.py
@@ -37,28 +37,6 @@ def cosineSimilarity(docWeights, queryWeights):
     q = np.array(queryWeights)
 
     # use cache to store norms
-    try:
-        dj_norm = cache[tuple(docWeights)]
-    except KeyError:
-        dj_norm = np.linalg.norm(dj)
-        cache[tuple(docWeights)] = dj_norm
-    try:
-        q_norm = cache[tuple(queryWeights)]
-    except KeyError:
-        q_norm = np.linalg.norm(q)
-        cache[tuple(queryWeights)] = q_norm
-    #print(q, dj)
-    score = np.dot(dj, q) / (dj_norm * q_norm)
-    #print(score)
-    return float(score)
-
-
-def cosineSimilarityHybrid(docWeights, queryWeights):
-    cache = NormCache()
-    dj = np.array(docWeights)
-    q = np.array(queryWeights)
-
-    # use cache to store norms
     dj_norm = np.linalg.norm(dj)
     try:
         q_norm = cache[tuple(queryWeights)]
@@ -68,14 +46,6 @@ def cosineSimilarityHybrid(docWeights, queryWeights):
     #print(q, dj)
     score = np.dot(dj, q) / (dj_norm * q_norm)
     #print(score)
-    return float(score)
-
-
-def oldCosineSimilarity(docWeights, queryWeights):
-    dj = np.array(docWeights)
-    q = np.array(queryWeights)
-
-    score = np.dot(dj, q) / (np.linalg.norm(dj) * np.linalg.norm(q))
     return float(score)
 
 
@@ -117,79 +87,3 @@ class NormCache(object):
         return getattr(self.instance, name)
     def __setattr__(self, name, value):
         return setattr(self.instance, name, value)
-
-
-
-def profileTime(func, docs, query, warm=False):
-    import cProfile
-    import pstats
-    if not warm:
-        NormCache().clear()
-
-    pr = cProfile.Profile()
-    results = []
-    for doc in docs:
-        pr.enable()
-        r = func(doc, query)
-        pr.disable()
-        results.append(r)
-    
-    print("\nTime statistics for {}".format(func.__name__))
-    ps = pstats.Stats(pr)
-    ps.sort_stats('time')
-    ps.print_stats(10)
-
-
-def profileMemory(func, docs, query, warm=False):
-    import tracemalloc
-    snapshots = {}
-    if not warm:
-        NormCache().clear()
-
-    tracemalloc.start()
-    results = []
-    for doc in docs:
-        r = func(doc, query)
-        results.append(r)
-
-    snapshots[func.__name__] = tracemalloc.take_snapshot()
-    used, peak = tracemalloc.get_traced_memory()
-    tracemalloc.stop()
-
-    print("Memory Snapshot for {}".format(func.__name__))
-    print("Used memory={}, Peak memory={}".format(used, peak))
-    for stat in snapshots[func.__name__].statistics('lineno'):
-        print(stat)
-
-
-if __name__ == "__main__":
-    import random
-
-    # data
-    DOC_SIZE = 5
-    SAMPLE_SIZE = 200000
-    docs = []
-    for i in range(0, SAMPLE_SIZE):
-        docs.append([random.random() for i in range(DOC_SIZE)])
-    query = [random.random() for i in range(0, DOC_SIZE)]
-
-    print("Testrun for {} documents each containing {} values".format(SAMPLE_SIZE, DOC_SIZE))
-    print("\nUncached cosine similarity")
-    profileTime(oldCosineSimilarity, docs, query)
-    profileMemory(oldCosineSimilarity, docs, query)
-
-    print("\nCached cosine similarity")
-    profileTime(cosineSimilarity, docs, query)
-    profileMemory(cosineSimilarity, docs, query)
-
-    print("\nWarm cached cosine similarity")
-    profileTime(cosineSimilarity, docs, query, warm=True)
-    profileMemory(cosineSimilarity, docs, query, warm=True)
-
-    print("\nOnly query norms cached cosine similarity")
-    profileTime(cosineSimilarityHybrid, docs, query, warm=False)
-    profileMemory(cosineSimilarityHybrid, docs, query, warm=False)
-
-    print("\nWarm only query norms cached cosine similarity")
-    profileTime(cosineSimilarityHybrid, docs, query, warm=True)
-    profileMemory(cosineSimilarityHybrid, docs, query, warm=True)


### PR DESCRIPTION
Time and Memory Profiling results:

```
Testrun for 200000 documents each containing 5 values

Uncached cosine similarity

Time statistics for oldCosineSimilarity
         4200000 function calls in 3.656 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   400000    1.327    0.000    2.560    0.000 /usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:2014(norm)
   600000    0.567    0.000    0.567    0.000 {built-in method dot}
   800000    0.476    0.000    0.476    0.000 {built-in method array}
   200000    0.459    0.000    3.637    0.000 cse/WeightCalculation.py:56(oldCosineSimilarity)
   400000    0.241    0.000    0.241    0.000 {method 'ravel' of 'numpy.ndarray' objects}
   400000    0.229    0.000    0.291    0.000 /usr/local/lib/python3.4/dist-packages/numpy/core/numeric.py:463(asarray)
   800000    0.192    0.000    0.192    0.000 {built-in method issubclass}
   400000    0.146    0.000    0.235    0.000 /usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:111(isComplexType)
   200000    0.018    0.000    0.018    0.000 {method 'disable' of '_lsprof.Profiler' objects}


Memory Snapshot for oldCosineSimilarity
Used memory=41455344, Peak memory=44127272
cse/WeightCalculation.py:44: size=16.8 MiB, count=200003, average=88 B
cse/WeightCalculation.py:89: size=12.0 MiB, count=1, average=12.0 MiB
/usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:2168: size=4688 KiB, count=200001, average=24 B
cse/WeightCalculation.py:53: size=4685 KiB, count=199900, average=24 B
cse/WeightCalculation.py:135: size=1633 KiB, count=2, average=816 KiB
cse/WeightCalculation.py:134: size=624 B, count=1, average=624 B
cse/WeightCalculation.py:137: size=448 B, count=1, average=448 B
cse/WeightCalculation.py:49: size=88 B, count=1, average=88 B
/usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:2153: size=64 B, count=1, average=64 B
/usr/local/lib/python3.4/dist-packages/numpy/core/numeric.py:531: size=64 B, count=1, average=64 B
/usr/lib/python3.4/tracemalloc.py:485: size=64 B, count=1, average=64 B

Cached cosine similarity

Time statistics for cosineSimilarity
         3400009 function calls in 3.387 seconds

   Ordered by: internal time
   List reduced from 12 to 10 due to restriction <10>

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200000    0.905    0.000    3.369    0.000 cse/WeightCalculation.py:34(cosineSimilarity)
   200001    0.760    0.000    1.452    0.000 /usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:2014(norm)
   600001    0.465    0.000    0.465    0.000 {built-in method array}
   400001    0.409    0.000    0.409    0.000 {built-in method dot}
   400000    0.224    0.000    0.224    0.000 cse/WeightCalculation.py:86(__getitem__)
   200001    0.134    0.000    0.134    0.000 {method 'ravel' of 'numpy.ndarray' objects}
   200001    0.125    0.000    0.156    0.000 /usr/local/lib/python3.4/dist-packages/numpy/core/numeric.py:463(asarray)
   200001    0.111    0.000    0.111    0.000 cse/WeightCalculation.py:88(__setitem__)
   400002    0.106    0.000    0.106    0.000 {built-in method issubclass}
   200001    0.078    0.000    0.126    0.000 /usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:111(isComplexType)


Memory Snapshot for cosineSimilarity
Used memory=41276776, Peak memory=43950344
cse/WeightCalculation.py:44: size=16.6 MiB, count=198002, average=88 B
cse/WeightCalculation.py:89: size=12.0 MiB, count=1, average=12.0 MiB
/usr/local/lib/python3.4/dist-packages/numpy/linalg/linalg.py:2168: size=4688 KiB, count=200001, average=24 B
cse/WeightCalculation.py:53: size=4685 KiB, count=199900, average=24 B
cse/WeightCalculation.py:135: size=1633 KiB, count=1, average=1633 KiB

Warm cached cosine similarity

Time statistics for cosineSimilarity
         1600000 function calls in 1.432 seconds

   Ordered by: internal time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   200000    0.546    0.000    1.414    0.000 cse/WeightCalculation.py:34(cosineSimilarity)
   400000    0.410    0.000    0.410    0.000 {built-in method array}
   400000    0.209    0.000    0.209    0.000 cse/WeightCalculation.py:86(__getitem__)
   200000    0.203    0.000    0.203    0.000 {built-in method dot}
   200000    0.046    0.000    0.046    0.000 cse/WeightCalculation.py:94(__new__)
   200000    0.018    0.000    0.018    0.000 {method 'disable' of '_lsprof.Profiler' objects}


Memory Snapshot for cosineSimilarity
Used memory=6469632, Peak memory=6474864
cse/WeightCalculation.py:53: size=4685 KiB, count=199900, average=24 B
cse/WeightCalculation.py:135: size=1633 KiB, count=1, average=1633 KiB
```